### PR TITLE
track when a job is enqueued

### DIFF
--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -95,7 +95,7 @@ module Resque
         Resque.push(queue,
           :class => klass.to_s,
           :args => args,
-          :queued_since => Time.now.utc.iso8601
+          :enqueued_at => Time.now.utc.iso8601
         )
       end
     end

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -92,7 +92,11 @@ module Resque
         # decode(encode(args)) to ensure that args are normalized in the same manner as a non-inline job
         new(:inline, {'class' => klass, 'args' => decode(encode(args))}).perform
       else
-        Resque.push(queue, :class => klass.to_s, :args => args)
+        Resque.push(queue,
+          :class => klass.to_s,
+          :args => args,
+          :queued_since => Time.now.utc.iso8601
+        )
       end
     end
 
@@ -131,7 +135,13 @@ module Resque
           end
         end
       else
-        destroyed += data_store.remove_from_queue(queue, encode(:class => klass, :args => args))
+        normalized_args = decode(encode(args))
+        data_store.everything_in_queue(queue).each do |string|
+          decoded = decode(string)
+          if decoded['class'] == klass && decoded['args'] == normalized_args
+            destroyed += data_store.remove_from_queue(queue, string).to_i
+          end
+        end
       end
 
       destroyed

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -715,9 +715,11 @@ module Resque
     # Given a job, tells Redis we're working on it. Useful for seeing
     # what workers are doing and when.
     def working_on(job)
+      queued_since = job.payload['queued_since'] || Time.now.utc.iso8601
       data = encode \
         :queue   => job.queue,
         :run_at  => Time.now.utc.iso8601,
+        :queued_since => queued_since,
         :payload => job.payload
       data_store.set_worker_payload(self,data)
       state_change

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -715,11 +715,11 @@ module Resque
     # Given a job, tells Redis we're working on it. Useful for seeing
     # what workers are doing and when.
     def working_on(job)
-      queued_since = job.payload['queued_since'] || Time.now.utc.iso8601
+      enqueued_at = job.payload['enqueued_at'] || Time.now.utc.iso8601
       data = encode \
         :queue   => job.queue,
         :run_at  => Time.now.utc.iso8601,
-        :queued_since => queued_since,
+        :enqueued_at => enqueued_at,
         :payload => job.payload
       data_store.set_worker_payload(self,data)
       state_change

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -48,7 +48,7 @@ describe "Resque" do
     assert_equal SomeJob, job.payload_class
     assert_equal 20, job.args[0]
     assert_equal '/tmp', job.args[1]
-    assert job.payload['queued_since']
+    assert job.payload['enqueued_at']
   end
 
   it "can re-queue jobs" do

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -48,6 +48,7 @@ describe "Resque" do
     assert_equal SomeJob, job.payload_class
     assert_equal 20, job.args[0]
     assert_equal '/tmp', job.args[1]
+    assert job.payload['queued_since']
   end
 
   it "can re-queue jobs" do

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -162,7 +162,7 @@ describe "Resque::Worker" do
     now = Time.now.utc.iso8601
     @worker.working_on(job)
     assert_equal now, @worker.processing['run_at']
-    assert @worker.processing['queued_since']
+    assert @worker.processing['enqueued_at']
   end
 
   it "fails uncompleted jobs with DirtyExit by default on exit" do
@@ -529,9 +529,9 @@ describe "Resque::Worker" do
         task = @worker.job
         assert_equal "SomeJob", task['payload']['class']
         assert_equal [20, "/tmp"], task['payload']['args']
-        assert task['payload']['queued_since']
+        assert task['payload']['enqueued_at']
         assert task['run_at']
-        assert_equal task['payload']['queued_since'], task['queued_since']
+        assert_equal task['payload']['enqueued_at'], task['enqueued_at']
         assert_equal 'jobs', task['queue']
       end
     end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -162,6 +162,7 @@ describe "Resque::Worker" do
     now = Time.now.utc.iso8601
     @worker.working_on(job)
     assert_equal now, @worker.processing['run_at']
+    assert @worker.processing['queued_since']
   end
 
   it "fails uncompleted jobs with DirtyExit by default on exit" do
@@ -526,8 +527,11 @@ describe "Resque::Worker" do
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
         task = @worker.job
-        assert_equal({"args"=>[20, "/tmp"], "class"=>"SomeJob"}, task['payload'])
+        assert_equal "SomeJob", task['payload']['class']
+        assert_equal [20, "/tmp"], task['payload']['args']
+        assert task['payload']['queued_since']
         assert task['run_at']
+        assert_equal task['payload']['queued_since'], task['queued_since']
         assert_equal 'jobs', task['queue']
       end
     end


### PR DESCRIPTION
## Context
Resque by default makes no attempt to track how long a job sits in the queue between being `Resque.enqueue`'d and finally being picked up and processed by a worker.

this is deeply unfortunate, as having access to this information would let us know the mean, median, p95, p99, etc. latencies of queues and adjust our infrastructure accordingly.

While it would be possible to track this by passing a timestamp as an argument for each resque job, this to me seems like it would have a much wider surface area for failure/bugs when done retroactively to phonetrac compared to making a change to resque itself.

## Changes
in vanilla resque, the redis representation of a resque job waiting in a queue looks like this:
```
{
  "class" => "AutomatorWorker",
  "args" => [321710, 4159996217, "start", {}]
}
```

and the redis representation of the same job once it is picked up by a worker looks like this:
```
{
  "queue" => "triggers",
  "run_at" => "2026-04-16T19:37:29Z",
  "payload" => {"class" => "AutomatorWorker", "args" => [321710, 4159996217, "start", {}]}
}
```
where `run_at` is the time the worker starting handling the job

This PR adds an extra key `enqueued_at ` to this representation (name stolen from ActiveJob which happens to include this themselves as a hidden job arg)

the new representations would look like this:
```
{
  "class" => "AutomatorWorker",
  "enqueued_at" => "2026-04-17T13:25:57Z",
  "args" => [321710, 4159996217, "start", {}]
}
```

```
{
  "queue" => "triggers",
  "run_at" => "2026-04-16T19:37:29Z",
  "payload" => {"class" => "AutomatorWorker", "enqueued_at" => "2026-04-17T13:25:57Z", "args" => [321710, 4159996217, "start", {}]}
}
```

This is a minor addition which shouldn't significantly impact how resque works

> with the exception of the internal `Resque::Job.destroy` method that AI found should be slightly modified since it serialized the job payload and looked for exact matches (which would never be true anymore since the timestamps now change)


P.S. this PR has failing tests for reasons unrelated to the content of the PR, a bunch of tests will fail even for no-op branches https://github.com/calltracking/resque/pull/4.
However, it seems like each bucket is running the same exact tests but with different software versions(?), so the fact that at least some passed with 0 errors means that tests should be good



## Testing:

while this PR is not merged, you can try this branch in your dev environment by editing your Gemfile like so:
```
- gem 'resque', git: 'https://github.com/calltracking/resque.git'
+ gem 'resque', git: 'https://github.com/calltracking/resque.git', branch: 'ivan/track_enqueue_time'
```
don't forget to also restart your puma, resque, and scheduler services
